### PR TITLE
Learnset Editor: Allow custom sorting of level up moves

### DIFF
--- a/DS_Map/Editors/EvolutionsEditor.cs
+++ b/DS_Map/Editors/EvolutionsEditor.cs
@@ -16,7 +16,7 @@ namespace DSPRE {
         private int currentLoadedId = 0;
         private EvolutionFile currentLoadedFile = null;
 
-        private static bool dirty = false;
+        public bool dirty = false;
         private static readonly string formName = "Evolutions Editor";
 
         private (ComboBox m, Label l, NumericUpDown p, ComboBox t)[] evoRows;
@@ -181,6 +181,7 @@ namespace DSPRE {
                 dirty = false;
                 this.Text = formName;
             }
+            _parent.UpdateTabPageNames();
         }
 
         private void evoMethodComboBox1_SelectedIndexChanged(object sender, EventArgs e) {

--- a/DS_Map/Editors/LearnsetEditor.Designer.cs
+++ b/DS_Map/Editors/LearnsetEditor.Designer.cs
@@ -32,24 +32,26 @@
             this.groupBox2 = new System.Windows.Forms.GroupBox();
             this.movesListBox = new System.Windows.Forms.ListBox();
             this.groupBox3 = new System.Windows.Forms.GroupBox();
-            this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
+            this.editLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
+            this.entryCountLabel = new System.Windows.Forms.Label();
             this.descriptorLabel = new System.Windows.Forms.Label();
             this.addMoveButton = new System.Windows.Forms.Button();
             this.deleteMoveButton = new System.Windows.Forms.Button();
             this.editMoveButton = new System.Windows.Forms.Button();
             this.levelNumericUpDown = new System.Windows.Forms.NumericUpDown();
-            this.label1 = new System.Windows.Forms.Label();
-            this.moveInputComboBox = new DSPRE.InputComboBox();
+            this.levelLabel = new System.Windows.Forms.Label();
             this.statusLabel = new System.Windows.Forms.Label();
+            this.moveUpButton = new System.Windows.Forms.Button();
+            this.moveDownButton = new System.Windows.Forms.Button();
+            this.moveInputComboBox = new DSPRE.InputComboBox();
             this.pokemonNameInputComboBox = new DSPRE.InputComboBox();
-            this.entryCountLabel = new System.Windows.Forms.Label();
             this.tableLayoutPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pokemonPictureBox)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.monNumberNumericUpDown)).BeginInit();
             this.tableLayoutPanel2.SuspendLayout();
             this.groupBox2.SuspendLayout();
             this.groupBox3.SuspendLayout();
-            this.tableLayoutPanel3.SuspendLayout();
+            this.editLayoutPanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.levelNumericUpDown)).BeginInit();
             this.SuspendLayout();
             // 
@@ -66,23 +68,21 @@
             this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel2, 0, 1);
             this.tableLayoutPanel1.Controls.Add(this.pokemonNameInputComboBox, 1, 0);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(7, 6);
-            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(5, 5);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 11.58022F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 88.41978F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(654, 553);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(491, 449);
             this.tableLayoutPanel1.TabIndex = 0;
             // 
             // saveDataButton
             // 
             this.saveDataButton.Dock = System.Windows.Forms.DockStyle.Fill;
             this.saveDataButton.Image = ((System.Drawing.Image)(resources.GetObject("saveDataButton.Image")));
-            this.saveDataButton.Location = new System.Drawing.Point(588, 4);
-            this.saveDataButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.saveDataButton.Location = new System.Drawing.Point(441, 3);
             this.saveDataButton.Name = "saveDataButton";
-            this.saveDataButton.Size = new System.Drawing.Size(62, 56);
+            this.saveDataButton.Size = new System.Drawing.Size(47, 45);
             this.saveDataButton.TabIndex = 30;
             this.saveDataButton.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.saveDataButton.UseVisualStyleBackColor = true;
@@ -91,10 +91,9 @@
             // pokemonPictureBox
             // 
             this.pokemonPictureBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.pokemonPictureBox.Location = new System.Drawing.Point(4, 4);
-            this.pokemonPictureBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.pokemonPictureBox.Location = new System.Drawing.Point(3, 3);
             this.pokemonPictureBox.Name = "pokemonPictureBox";
-            this.pokemonPictureBox.Size = new System.Drawing.Size(59, 56);
+            this.pokemonPictureBox.Size = new System.Drawing.Size(44, 45);
             this.pokemonPictureBox.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
             this.pokemonPictureBox.TabIndex = 12;
             this.pokemonPictureBox.TabStop = false;
@@ -102,10 +101,9 @@
             // monNumberNumericUpDown
             // 
             this.monNumberNumericUpDown.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.monNumberNumericUpDown.Location = new System.Drawing.Point(465, 21);
-            this.monNumberNumericUpDown.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.monNumberNumericUpDown.Location = new System.Drawing.Point(349, 15);
             this.monNumberNumericUpDown.Name = "monNumberNumericUpDown";
-            this.monNumberNumericUpDown.Size = new System.Drawing.Size(115, 22);
+            this.monNumberNumericUpDown.Size = new System.Drawing.Size(86, 20);
             this.monNumberNumericUpDown.TabIndex = 16;
             this.monNumberNumericUpDown.ValueChanged += new System.EventHandler(this.monNumberNumericUpDown_ValueChanged);
             // 
@@ -115,29 +113,26 @@
             this.tableLayoutPanel1.SetColumnSpan(this.tableLayoutPanel2, 4);
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 8.303955F));
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 8.303955F));
-            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 27F));
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tableLayoutPanel2.Controls.Add(this.groupBox2, 0, 0);
             this.tableLayoutPanel2.Controls.Add(this.groupBox3, 1, 0);
             this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel2.Location = new System.Drawing.Point(4, 68);
-            this.tableLayoutPanel2.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.tableLayoutPanel2.Location = new System.Drawing.Point(3, 54);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-            this.tableLayoutPanel2.Padding = new System.Windows.Forms.Padding(7, 6, 7, 6);
+            this.tableLayoutPanel2.Padding = new System.Windows.Forms.Padding(5);
             this.tableLayoutPanel2.RowCount = 1;
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 470F));
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(646, 481);
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 382F));
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(485, 392);
             this.tableLayoutPanel2.TabIndex = 17;
             // 
             // groupBox2
             // 
             this.groupBox2.Controls.Add(this.movesListBox);
             this.groupBox2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.groupBox2.Location = new System.Drawing.Point(11, 10);
-            this.groupBox2.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.groupBox2.Location = new System.Drawing.Point(8, 8);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.groupBox2.Size = new System.Drawing.Size(308, 461);
+            this.groupBox2.Size = new System.Drawing.Size(231, 376);
             this.groupBox2.TabIndex = 34;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "View";
@@ -146,79 +141,93 @@
             // 
             this.movesListBox.Dock = System.Windows.Forms.DockStyle.Fill;
             this.movesListBox.FormattingEnabled = true;
-            this.movesListBox.ItemHeight = 16;
-            this.movesListBox.Location = new System.Drawing.Point(4, 19);
-            this.movesListBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.movesListBox.Location = new System.Drawing.Point(3, 16);
+            this.movesListBox.Margin = new System.Windows.Forms.Padding(2);
             this.movesListBox.Name = "movesListBox";
-            this.movesListBox.Size = new System.Drawing.Size(300, 438);
+            this.movesListBox.Size = new System.Drawing.Size(225, 357);
             this.movesListBox.TabIndex = 0;
             this.movesListBox.SelectedIndexChanged += new System.EventHandler(this.movesListBox_SelectedIndexChanged);
             // 
             // groupBox3
             // 
-            this.groupBox3.Controls.Add(this.tableLayoutPanel3);
+            this.groupBox3.Controls.Add(this.editLayoutPanel);
             this.groupBox3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.groupBox3.Location = new System.Drawing.Point(327, 10);
-            this.groupBox3.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.groupBox3.Location = new System.Drawing.Point(245, 8);
             this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.groupBox3.Size = new System.Drawing.Size(308, 461);
+            this.groupBox3.Size = new System.Drawing.Size(232, 376);
             this.groupBox3.TabIndex = 35;
             this.groupBox3.TabStop = false;
             this.groupBox3.Text = "Edit";
             // 
-            // tableLayoutPanel3
+            // editLayoutPanel
             // 
-            this.tableLayoutPanel3.ColumnCount = 3;
-            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33333F));
-            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33333F));
-            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33333F));
-            this.tableLayoutPanel3.Controls.Add(this.entryCountLabel, 0, 5);
-            this.tableLayoutPanel3.Controls.Add(this.descriptorLabel, 0, 1);
-            this.tableLayoutPanel3.Controls.Add(this.addMoveButton, 0, 4);
-            this.tableLayoutPanel3.Controls.Add(this.deleteMoveButton, 2, 4);
-            this.tableLayoutPanel3.Controls.Add(this.editMoveButton, 1, 4);
-            this.tableLayoutPanel3.Controls.Add(this.levelNumericUpDown, 1, 2);
-            this.tableLayoutPanel3.Controls.Add(this.label1, 0, 2);
-            this.tableLayoutPanel3.Controls.Add(this.moveInputComboBox, 0, 0);
-            this.tableLayoutPanel3.Controls.Add(this.statusLabel, 0, 3);
-            this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel3.Location = new System.Drawing.Point(4, 19);
-            this.tableLayoutPanel3.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.tableLayoutPanel3.Name = "tableLayoutPanel3";
-            this.tableLayoutPanel3.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.tableLayoutPanel3.RowCount = 6;
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 34.50088F));
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 65.49912F));
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 144F));
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 44F));
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 26F));
-            this.tableLayoutPanel3.Size = new System.Drawing.Size(226, 357);
-            this.tableLayoutPanel3.TabIndex = 0;
+            this.editLayoutPanel.ColumnCount = 3;
+            this.editLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33112F));
+            this.editLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33444F));
+            this.editLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33444F));
+            this.editLayoutPanel.Controls.Add(this.moveDownButton, 1, 4);
+            this.editLayoutPanel.Controls.Add(this.moveUpButton, 0, 4);
+            this.editLayoutPanel.Controls.Add(this.addMoveButton, 0, 5);
+            this.editLayoutPanel.Controls.Add(this.deleteMoveButton, 2, 5);
+            this.editLayoutPanel.Controls.Add(this.editMoveButton, 1, 5);
+            this.editLayoutPanel.Controls.Add(this.levelNumericUpDown, 1, 2);
+            this.editLayoutPanel.Controls.Add(this.moveInputComboBox, 0, 0);
+            this.editLayoutPanel.Controls.Add(this.descriptorLabel, 0, 1);
+            this.editLayoutPanel.Controls.Add(this.entryCountLabel, 0, 6);
+            this.editLayoutPanel.Controls.Add(this.levelLabel, 0, 2);
+            this.editLayoutPanel.Controls.Add(this.statusLabel, 0, 3);
+            this.editLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.editLayoutPanel.Location = new System.Drawing.Point(3, 16);
+            this.editLayoutPanel.Margin = new System.Windows.Forms.Padding(2);
+            this.editLayoutPanel.Name = "editLayoutPanel";
+            this.editLayoutPanel.Padding = new System.Windows.Forms.Padding(2);
+            this.editLayoutPanel.RowCount = 7;
+            this.editLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
+            this.editLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
+            this.editLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
+            this.editLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
+            this.editLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 50F));
+            this.editLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 50F));
+            this.editLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.editLayoutPanel.Size = new System.Drawing.Size(226, 357);
+            this.editLayoutPanel.TabIndex = 0;
+            // 
+            // entryCountLabel
+            // 
+            this.entryCountLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.entryCountLabel.AutoSize = true;
+            this.editLayoutPanel.SetColumnSpan(this.entryCountLabel, 3);
+            this.entryCountLabel.Location = new System.Drawing.Point(4, 334);
+            this.entryCountLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.entryCountLabel.Name = "entryCountLabel";
+            this.entryCountLabel.Padding = new System.Windows.Forms.Padding(1, 4, 1, 4);
+            this.entryCountLabel.Size = new System.Drawing.Size(70, 21);
+            this.entryCountLabel.TabIndex = 9;
+            this.entryCountLabel.Text = "Entry Count: ";
+            this.entryCountLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // descriptorLabel
             // 
+            this.descriptorLabel.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.descriptorLabel.AutoSize = true;
-            this.tableLayoutPanel3.SetColumnSpan(this.descriptorLabel, 3);
-            this.descriptorLabel.Location = new System.Drawing.Point(7, 52);
-            this.descriptorLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.editLayoutPanel.SetColumnSpan(this.descriptorLabel, 3);
+            this.descriptorLabel.Location = new System.Drawing.Point(5, 45);
             this.descriptorLabel.Name = "descriptorLabel";
-            this.descriptorLabel.Padding = new System.Windows.Forms.Padding(1, 6, 1, 6);
-            this.descriptorLabel.Size = new System.Drawing.Size(71, 28);
+            this.descriptorLabel.Padding = new System.Windows.Forms.Padding(1, 5, 1, 5);
+            this.descriptorLabel.Size = new System.Drawing.Size(57, 23);
             this.descriptorLabel.TabIndex = 8;
             this.descriptorLabel.Text = "Descriptor";
             // 
             // addMoveButton
             // 
-            this.addMoveButton.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.addMoveButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.addMoveButton.Enabled = false;
             this.addMoveButton.Image = global::DSPRE.Properties.Resources.addIcon;
             this.addMoveButton.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.addMoveButton.Location = new System.Drawing.Point(4, 286);
+            this.addMoveButton.Location = new System.Drawing.Point(4, 201);
             this.addMoveButton.Margin = new System.Windows.Forms.Padding(2);
             this.addMoveButton.Name = "addMoveButton";
-            this.addMoveButton.Size = new System.Drawing.Size(70, 40);
+            this.addMoveButton.Size = new System.Drawing.Size(69, 32);
             this.addMoveButton.TabIndex = 1;
             this.addMoveButton.Text = "Add";
             this.addMoveButton.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -227,14 +236,14 @@
             // 
             // deleteMoveButton
             // 
-            this.deleteMoveButton.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.deleteMoveButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.deleteMoveButton.Enabled = false;
             this.deleteMoveButton.Image = global::DSPRE.Properties.Resources.deleteIcon;
             this.deleteMoveButton.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.deleteMoveButton.Location = new System.Drawing.Point(152, 286);
+            this.deleteMoveButton.Location = new System.Drawing.Point(151, 201);
             this.deleteMoveButton.Margin = new System.Windows.Forms.Padding(2);
             this.deleteMoveButton.Name = "deleteMoveButton";
-            this.deleteMoveButton.Size = new System.Drawing.Size(70, 40);
+            this.deleteMoveButton.Size = new System.Drawing.Size(71, 32);
             this.deleteMoveButton.TabIndex = 2;
             this.deleteMoveButton.Text = "Delete";
             this.deleteMoveButton.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -243,14 +252,14 @@
             // 
             // editMoveButton
             // 
-            this.editMoveButton.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.editMoveButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.editMoveButton.Enabled = false;
             this.editMoveButton.Image = global::DSPRE.Properties.Resources.RenameIcon;
             this.editMoveButton.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.editMoveButton.Location = new System.Drawing.Point(78, 286);
+            this.editMoveButton.Location = new System.Drawing.Point(77, 201);
             this.editMoveButton.Margin = new System.Windows.Forms.Padding(2);
             this.editMoveButton.Name = "editMoveButton";
-            this.editMoveButton.Size = new System.Drawing.Size(70, 40);
+            this.editMoveButton.Size = new System.Drawing.Size(70, 32);
             this.editMoveButton.TabIndex = 3;
             this.editMoveButton.Text = "Edit";
             this.editMoveButton.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -259,50 +268,84 @@
             // 
             // levelNumericUpDown
             // 
-            this.tableLayoutPanel3.SetColumnSpan(this.levelNumericUpDown, 2);
-            this.levelNumericUpDown.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.levelNumericUpDown.Location = new System.Drawing.Point(103, 148);
-            this.levelNumericUpDown.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.levelNumericUpDown.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.editLayoutPanel.SetColumnSpan(this.levelNumericUpDown, 2);
+            this.levelNumericUpDown.Location = new System.Drawing.Point(77, 82);
+            this.levelNumericUpDown.Margin = new System.Windows.Forms.Padding(2);
             this.levelNumericUpDown.Name = "levelNumericUpDown";
-            this.levelNumericUpDown.Size = new System.Drawing.Size(191, 22);
+            this.levelNumericUpDown.Size = new System.Drawing.Size(145, 20);
             this.levelNumericUpDown.TabIndex = 4;
             this.levelNumericUpDown.ValueChanged += new System.EventHandler(this.levelNumericUpDown_ValueChanged);
             // 
-            // label1
+            // levelLabel
             // 
-            this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(6, 150);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(91, 16);
-            this.label1.TabIndex = 5;
-            this.label1.Text = "Level:";
+            this.levelLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.levelLabel.AutoSize = true;
+            this.levelLabel.Location = new System.Drawing.Point(4, 85);
+            this.levelLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.levelLabel.Name = "levelLabel";
+            this.levelLabel.Size = new System.Drawing.Size(69, 13);
+            this.levelLabel.TabIndex = 5;
+            this.levelLabel.Text = "Level:";
+            // 
+            // statusLabel
+            // 
+            this.statusLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.statusLabel.AutoSize = true;
+            this.editLayoutPanel.SetColumnSpan(this.statusLabel, 3);
+            this.statusLabel.Location = new System.Drawing.Point(4, 119);
+            this.statusLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.statusLabel.Name = "statusLabel";
+            this.statusLabel.Padding = new System.Windows.Forms.Padding(1, 5, 1, 5);
+            this.statusLabel.Size = new System.Drawing.Size(39, 23);
+            this.statusLabel.TabIndex = 7;
+            this.statusLabel.Text = "Status";
+            // 
+            // moveUpButton
+            // 
+            this.moveUpButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.moveUpButton.Enabled = false;
+            this.moveUpButton.Image = global::DSPRE.Properties.Resources.arrowup;
+            this.moveUpButton.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.moveUpButton.Location = new System.Drawing.Point(4, 151);
+            this.moveUpButton.Margin = new System.Windows.Forms.Padding(2);
+            this.moveUpButton.Name = "moveUpButton";
+            this.moveUpButton.Size = new System.Drawing.Size(69, 32);
+            this.moveUpButton.TabIndex = 10;
+            this.moveUpButton.Text = "Move";
+            this.moveUpButton.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.moveUpButton.UseVisualStyleBackColor = true;
+            this.moveUpButton.Click += new System.EventHandler(this.moveUpButton_Click);
+            // 
+            // moveDownButton
+            // 
+            this.moveDownButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.moveDownButton.Enabled = false;
+            this.moveDownButton.Image = global::DSPRE.Properties.Resources.arrowdown;
+            this.moveDownButton.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.moveDownButton.Location = new System.Drawing.Point(77, 151);
+            this.moveDownButton.Margin = new System.Windows.Forms.Padding(2);
+            this.moveDownButton.Name = "moveDownButton";
+            this.moveDownButton.Size = new System.Drawing.Size(70, 32);
+            this.moveDownButton.TabIndex = 11;
+            this.moveDownButton.Text = "Move";
+            this.moveDownButton.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.moveDownButton.UseVisualStyleBackColor = true;
+            this.moveDownButton.Click += new System.EventHandler(this.moveDownButton_Click);
             // 
             // moveInputComboBox
             // 
             this.moveInputComboBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.moveInputComboBox.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
             this.moveInputComboBox.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
-            this.tableLayoutPanel3.SetColumnSpan(this.moveInputComboBox, 3);
+            this.editLayoutPanel.SetColumnSpan(this.moveInputComboBox, 3);
             this.moveInputComboBox.FormattingEnabled = true;
-            this.moveInputComboBox.Location = new System.Drawing.Point(6, 15);
-            this.moveInputComboBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.moveInputComboBox.Location = new System.Drawing.Point(4, 11);
+            this.moveInputComboBox.Margin = new System.Windows.Forms.Padding(2);
             this.moveInputComboBox.Name = "moveInputComboBox";
-            this.moveInputComboBox.Size = new System.Drawing.Size(288, 24);
+            this.moveInputComboBox.Size = new System.Drawing.Size(218, 21);
             this.moveInputComboBox.TabIndex = 6;
             this.moveInputComboBox.SelectedIndexChanged += new System.EventHandler(this.moveInputComboBox_SelectedIndexChanged);
-            // 
-            // statusLabel
-            // 
-            this.statusLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.statusLabel.AutoSize = true;
-            this.tableLayoutPanel3.SetColumnSpan(this.statusLabel, 3);
-            this.statusLabel.Location = new System.Drawing.Point(5, 261);
-            this.statusLabel.Name = "statusLabel";
-            this.statusLabel.Padding = new System.Windows.Forms.Padding(1, 6, 1, 6);
-            this.statusLabel.Size = new System.Drawing.Size(46, 28);
-            this.statusLabel.TabIndex = 7;
-            this.statusLabel.Text = "Status";
             // 
             // pokemonNameInputComboBox
             // 
@@ -310,38 +353,23 @@
             this.pokemonNameInputComboBox.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
             this.pokemonNameInputComboBox.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.pokemonNameInputComboBox.FormattingEnabled = true;
-            this.pokemonNameInputComboBox.Location = new System.Drawing.Point(71, 20);
-            this.pokemonNameInputComboBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.pokemonNameInputComboBox.Location = new System.Drawing.Point(53, 15);
             this.pokemonNameInputComboBox.Name = "pokemonNameInputComboBox";
-            this.pokemonNameInputComboBox.Size = new System.Drawing.Size(386, 24);
+            this.pokemonNameInputComboBox.Size = new System.Drawing.Size(290, 21);
             this.pokemonNameInputComboBox.TabIndex = 31;
             this.pokemonNameInputComboBox.SelectedIndexChanged += new System.EventHandler(this.pokemonNameInputComboBox_SelectedIndexChanged);
             // 
-            // entryCountLabel
-            // 
-            this.entryCountLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.entryCountLabel.AutoSize = true;
-            this.tableLayoutPanel3.SetColumnSpan(this.entryCountLabel, 3);
-            this.entryCountLabel.Location = new System.Drawing.Point(5, 332);
-            this.entryCountLabel.Name = "entryCountLabel";
-            this.entryCountLabel.Padding = new System.Windows.Forms.Padding(1, 5, 1, 5);
-            this.entryCountLabel.Size = new System.Drawing.Size(70, 23);
-            this.entryCountLabel.TabIndex = 9;
-            this.entryCountLabel.Text = "Entry Count: ";
-            this.entryCountLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
             // LearnsetEditor
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(668, 565);
+            this.ClientSize = new System.Drawing.Size(501, 459);
             this.Controls.Add(this.tableLayoutPanel1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "LearnsetEditor";
-            this.Padding = new System.Windows.Forms.Padding(7, 6, 7, 6);
+            this.Padding = new System.Windows.Forms.Padding(5);
             this.Text = "Learnset Editor";
             this.tableLayoutPanel1.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.pokemonPictureBox)).EndInit();
@@ -349,8 +377,8 @@
             this.tableLayoutPanel2.ResumeLayout(false);
             this.groupBox2.ResumeLayout(false);
             this.groupBox3.ResumeLayout(false);
-            this.tableLayoutPanel3.ResumeLayout(false);
-            this.tableLayoutPanel3.PerformLayout();
+            this.editLayoutPanel.ResumeLayout(false);
+            this.editLayoutPanel.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.levelNumericUpDown)).EndInit();
             this.ResumeLayout(false);
 
@@ -365,17 +393,19 @@
         private System.Windows.Forms.GroupBox groupBox2;
         private System.Windows.Forms.GroupBox groupBox3;
         private System.Windows.Forms.ListBox movesListBox;
-        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel3;
+        private System.Windows.Forms.TableLayoutPanel editLayoutPanel;
         private System.Windows.Forms.Button addMoveButton;
         private System.Windows.Forms.Button deleteMoveButton;
         private System.Windows.Forms.Button editMoveButton;
         private System.Windows.Forms.NumericUpDown levelNumericUpDown;
-        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label levelLabel;
         private InputComboBox moveInputComboBox;
         private System.Windows.Forms.Label descriptorLabel;
         private System.Windows.Forms.Label statusLabel;
         public InputComboBox pokemonNameInputComboBox;
         public System.Windows.Forms.NumericUpDown monNumberNumericUpDown;
         private System.Windows.Forms.Label entryCountLabel;
+        private System.Windows.Forms.Button moveUpButton;
+        private System.Windows.Forms.Button moveDownButton;
     }
 }

--- a/DS_Map/Editors/LearnsetEditor.cs
+++ b/DS_Map/Editors/LearnsetEditor.cs
@@ -10,10 +10,18 @@ using MessageBox = System.Windows.Forms.MessageBox;
 namespace DSPRE {
     public partial class LearnsetEditor : Form {
 
+        private PokemonEditor _parent;
         private readonly string[] fileNames;
         private readonly string[] pokenames;
         private readonly string[] moveNames;
-        private PokemonEditor _parent;
+
+        private bool editMode = false;
+        public bool dirty = false;
+        private int currentLoadedId = 0;
+        private LearnsetData currentLoadedFile = null;
+
+        private readonly string formName = "Learnset Editor";
+
         private readonly string[] editButtonNames = new string[] {
             "Edit",
             "Confirm"
@@ -23,55 +31,190 @@ namespace DSPRE {
             "Delete",
             "Discard"
         };
-
-        private bool editMode = false;
-        private int currentLoadedId = 0;
-        private LearnsetData currentLoadedFile = null;
-
-        private bool dirty = false;
-        private readonly string formName = "Learnset Editor";
+        
 
         public LearnsetEditor(string[] moveNames, Control parent, PokemonEditor pokeEditor) {
-            this.moveNames = moveNames;
-            this._parent = pokeEditor;
+
             InitializeComponent();
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
+            this.FormBorderStyle = FormBorderStyle.None;
             this.Size = parent.Size;
             this.Anchor = AnchorStyles.Left | AnchorStyles.Right | AnchorStyles.Top | AnchorStyles.Bottom;
+
             Helpers.DisableHandlers();
 
-            BindingList<string> listMoveNames = new BindingList<string>(moveNames);
-            moveInputComboBox.DataSource = listMoveNames;
-
-            /* ---------------- */
-            int count = RomInfo.GetLearnsetFilesCount();
+            this._parent = pokeEditor;
+            this.moveNames = moveNames;
             this.pokenames = RomInfo.GetPokemonNames();
-            List<string> fileNames = new List<string>(count);
-            fileNames.AddRange(pokenames);
+            this.fileNames = GetFileNames();
 
-            for (int i = 0; i < PokeDatabase.PersonalData.personalExtraFiles.Length; i++) {
-                PokeDatabase.PersonalData.PersonalExtraFiles altFormEntry = PokeDatabase.PersonalData.personalExtraFiles[i];
-                fileNames.Add(fileNames[altFormEntry.monId] + " - " + altFormEntry.description);
-            }
+            InitDataRanges();
 
-            int extraEntries = fileNames.Count;
-            for (int i = 0; i < count - extraEntries; i++) {
-                fileNames.Add($"Extra entry {fileNames.Count}");
-            }
-
-            this.fileNames = fileNames.ToArray();
-            monNumberNumericUpDown.Maximum = fileNames.Count - 1;
-            pokemonNameInputComboBox.Items.AddRange(this.fileNames);
             /* ---------------- */
 
             descriptorLabel.Text = "";
             statusLabel.Text = "";
 
-            Helpers.EnableHandlers();
+            ChangeLoadedFile(1);
+
+            Helpers.EnableHandlers();            
+        }
+
+        private void InitDataRanges()
+        {
+            moveInputComboBox.DataSource = moveNames;
+            pokemonNameInputComboBox.DataSource = fileNames;
+            monNumberNumericUpDown.Minimum = 0;
+            monNumberNumericUpDown.Maximum = RomInfo.GetLearnsetFilesCount() - 1;
 
             pokemonNameInputComboBox.SelectedIndex = 1;
+            monNumberNumericUpDown.Value = 1;
+            levelNumericUpDown.Value = 1;
+            
         }
-        private void setDirty(bool status) {
+
+        private string[] GetFileNames() 
+        {
+
+            int learnsetCount = RomInfo.GetLearnsetFilesCount();
+
+            List<string> fileNames = new List<string>(RomInfo.GetLearnsetFilesCount());
+            fileNames.AddRange(pokenames);
+            for (int i = 0; i < PokeDatabase.PersonalData.personalExtraFiles.Length; i++) {
+                PokeDatabase.PersonalData.PersonalExtraFiles altFormEntry = PokeDatabase.PersonalData.personalExtraFiles[i];
+                fileNames.Add(fileNames[altFormEntry.monId] + " - " + altFormEntry.description);
+            }
+
+            for (int i = 0; i < learnsetCount - fileNames.Count; i++)
+            {
+                fileNames.Add($"Extra entry {fileNames.Count}");
+            }
+
+            return fileNames.ToArray();
+        }
+
+        public void ChangeLoadedFile(int learnsetID)
+        {
+            currentLoadedFile = new LearnsetData(learnsetID);
+            currentLoadedId = learnsetID;
+
+            monNumberNumericUpDown.Value = currentLoadedId;
+            pokemonNameInputComboBox.SelectedIndex = currentLoadedId;
+
+            UpdateMovesListFromFile();
+            UpdateEntryCountLabel();
+            UpdateButtonsOnMoveSelection();
+            UpdatePokePic();
+            UpdateAddEditStatus();
+            SetDirty(false);
+        }
+
+        private void UpdateMovesListFromFile()
+        {
+            movesListBox.BeginUpdate();
+            movesListBox.Items.Clear();
+            foreach (var elem in currentLoadedFile.list)
+            {
+                movesListBox.Items.Add(ElemToString(elem));
+            }
+            movesListBox.EndUpdate();
+        }
+
+        private void UpdateEntryCountLabel()
+        {
+            StringBuilder labelText = new StringBuilder("Entry Count: ");
+            labelText.Append(movesListBox.Items.Count);
+
+            if (movesListBox.Items.Count > LearnsetData.VanillaLimit)
+            {
+                labelText.Append("!");
+                entryCountLabel.ForeColor = Color.FromArgb(210, 120, 0);
+                entryCountLabel.Font = new Font(entryCountLabel.Font, FontStyle.Bold);
+            }
+            else
+            {
+                entryCountLabel.ForeColor = Color.Black;
+                entryCountLabel.Font = new Font(entryCountLabel.Font, FontStyle.Regular);
+            }
+
+            entryCountLabel.Text = labelText.ToString();
+        }
+
+        private void UpdatePokePic() 
+        {
+            int excess = currentLoadedId - pokenames.Length;
+            int toLoad = currentLoadedId; // Default to the current ID
+            try
+            {
+                if (excess >= 0)
+                {
+                    toLoad = PokeDatabase.PersonalData.personalExtraFiles[excess].iconId;
+                }
+            }
+            catch (IndexOutOfRangeException)
+            {
+                toLoad = 0;
+            }
+            finally
+            {
+                pokemonPictureBox.Image = DSUtils.GetPokePic(toLoad, pokemonPictureBox.Width, pokemonPictureBox.Height);
+            }
+        }
+
+        private void UpdateAddEditStatus()
+        {
+            (byte level, ushort move) newEntry = ((byte)levelNumericUpDown.Value, (ushort)moveInputComboBox.SelectedIndex);
+
+            if (currentLoadedFile == null)
+            {
+                return;
+            }
+
+            bool duplicate = currentLoadedFile.list.Contains(newEntry);
+
+            if (duplicate)
+            {
+                if (editMode)
+                {
+                    editMoveButton.Enabled = false;
+                }
+                else
+                {
+                    addMoveButton.Enabled = false;
+                }
+                statusLabel.Text = "Entry already exists!";
+            }
+            else
+            {
+                bool addable = IsValidEntry();
+                if (addable)
+                {
+                    statusLabel.Text = "";
+                }
+                else
+                {
+                    statusLabel.Text = "Invalid Move ID or Level!";
+                }
+
+                if (editMode)
+                {
+                    editMoveButton.Enabled = addable;
+                }
+                else
+                {
+                    addMoveButton.Enabled = addable;
+                }
+            }
+        }
+
+        public void SaveLearnsetData() {
+            if (currentLoadedFile == null) {
+                return;
+            }
+            currentLoadedFile.SaveToFileDefaultDir(currentLoadedId, false);
+            SetDirty(false);
+        }
+
+        private void SetDirty(bool status) {
             if (status) {
                 dirty = true;
                 this.Text = formName + "*";
@@ -79,90 +222,172 @@ namespace DSPRE {
                 dirty = false;
                 this.Text = formName;
             }
+            _parent.UpdateTabPageNames();
         }
-        public bool CheckDiscardChanges() {
+        public bool CheckDiscardChanges() 
+        {
             if (!dirty) {
                 return true;
             }
 
-            DialogResult res = MessageBox.Show(this, "Learnsets Editor\nThere are unsaved changes to the current Learnset data.\nDiscard and proceed?", "Learnset Editor - Unsaved changes", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
-            if (res.Equals(DialogResult.Yes)) {
-                return true;
+            DialogResult res = MessageBox.Show(this, 
+                "You have unsaved changes. Do you want to save them before switching Pokémon?",
+                "Learnset Editor - Unsaved changes", MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question);
+
+            if (res == DialogResult.Yes)
+            {
+                SaveLearnsetData();
             }
+            else if (res == DialogResult.Cancel)
+            {
+                monNumberNumericUpDown.Value = currentLoadedId;
+                pokemonNameInputComboBox.SelectedIndex = currentLoadedId;
+                return false; // Cancel the change
+            }          
 
-            monNumberNumericUpDown.Value = currentLoadedId;
-            pokemonNameInputComboBox.SelectedIndex = currentLoadedId;
-
-
-            return false;
+            return true;
         }
         private string ElemToString((ushort level, ushort move) elem) {
             return $"Lv. {elem.level}: {moveNames[elem.move]}";
         }
-        public void ChangeLoadedFile(int toLoad) {
-            currentLoadedId = toLoad;
-            currentLoadedFile = new LearnsetData(currentLoadedId);
-            PopulateAllFromCurrentFile();
-            UpdateButtonsOnMoveSelection();
-            
-            int excess = toLoad - pokenames.Length;
-            try {
-                if (excess >= 0) {
-                    toLoad = PokeDatabase.PersonalData.personalExtraFiles[excess].iconId;
-                }
-            } catch (IndexOutOfRangeException) {
-                toLoad = 0;
-            } finally {
-                pokemonPictureBox.Image = DSUtils.GetPokePic(toLoad, pokemonPictureBox.Width, pokemonPictureBox.Height);
-            }
-            setDirty(false);
+        private bool IsValidEntry()
+        {
+            return levelNumericUpDown.Value > 0 &&
+                moveInputComboBox.SelectedIndex > 0;
         }
 
-        private void PopulateAllFromCurrentFile() {
-            movesListBox.BeginUpdate();
-            movesListBox.Items.Clear();
-            foreach (var elem in currentLoadedFile.list) {
-                movesListBox.Items.Add(ElemToString(elem));
-            }
-
-            UpdateEntryCountLabel();
-            movesListBox.EndUpdate();
+        private void UpdateByEditMode()
+        {
+            int index = editMode == false ? 0 : 1;
+            editMoveButton.Text = editButtonNames[index];
+            deleteMoveButton.Text = deleteButtonNames[index];
         }
 
-        //-------------------------------
-        private void saveDataButton_Click(object sender, EventArgs e) {
-            currentLoadedFile.SaveToFileDefaultDir(currentLoadedId, true);
-            setDirty(false);
-        }
+        private void UpdateButtonsOnMoveSelection()
+        {
+            int sel = movesListBox.SelectedIndex;
 
-        private void pokemonNameInputComboBox_SelectedIndexChanged(object sender, EventArgs e) {
-            Update();
-            if (Helpers.HandlersDisabled) {
+            if (sel < 0)
+            {
+                editMoveButton.Enabled = false;
+                deleteMoveButton.Enabled = false;
+                moveUpButton.Enabled = false;
+                moveDownButton.Enabled = false;
                 return;
             }
+
+            editMoveButton.Enabled = true;
+            deleteMoveButton.Enabled = true;
+
+            int moveLevel = currentLoadedFile.list[sel].level;
+            int previousLevel = sel > 0 ? currentLoadedFile.list[sel - 1].level : 0;
+            int nextLevel = sel < currentLoadedFile.list.Count - 1 ? currentLoadedFile.list[sel + 1].level : 255;
+
+            // Allow reordering only if the levels are the same
+            moveUpButton.Enabled = moveLevel == previousLevel;
+            moveDownButton.Enabled = moveLevel == nextLevel;
+        }
+
+        private int InsertEntrySafe(int level, int moveID)
+        {
+            if (currentLoadedFile == null || !IsValidEntry())
+            {
+                return -1;
+            }
+
+            (byte level, ushort move) newEntry = ((byte)level, (ushort)moveID);
+
+            if (currentLoadedFile.list.Contains(newEntry))
+            {
+                MessageBox.Show(this, "This entry already exists!\nThis should not have happened.", "Learnset Editor - Duplicate Entry", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                AppLogger.Error("Learnset Editor: Attempted to insert a duplicate entry: " + newEntry);
+                return -1;
+            }
+
+            int index = currentLoadedFile.list.FindIndex(x => x.level > newEntry.level || (x.level == newEntry.level && x.move > newEntry.move));
+
+            if (index < 0)
+            {
+                currentLoadedFile.list.Add(newEntry);
+                return currentLoadedFile.list.Count - 1; // Add to the end if no larger entry is found
+            }
+            else
+            {
+                currentLoadedFile.list.Insert(index, newEntry);
+                return index; // Insert at the found index
+            }
+
+        }
+
+        private bool ShiftEntry(int index, int direction)
+        {
+            if (currentLoadedFile == null || index < 0 || index >= currentLoadedFile.list.Count)
+            {
+                return false; // Invalid index
+            }
+
+            int newIndex = index + direction;
+            if (newIndex < 0 || newIndex >= currentLoadedFile.list.Count)
+            {
+                return false; // Out of bounds
+            }
+            // Move the entry safely
+            SwapEntriesSafe(index, newIndex);
+            return true;
+        }
+
+        private bool SwapEntriesSafe(int indexA, int indexB)
+        {
+            if (currentLoadedFile == null || indexA < 0 || indexB < 0 || indexA >= currentLoadedFile.list.Count || indexB >= currentLoadedFile.list.Count)
+            {
+                return false; // Invalid indices
+            }
+            (byte level, ushort move) entryA = currentLoadedFile.list[indexA];
+            (byte level, ushort move) entryB = currentLoadedFile.list[indexB];
+            // Swap the entries
+            currentLoadedFile.list[indexA] = entryB;
+            currentLoadedFile.list[indexB] = entryA;
+
+            return true; // Successfully swapped
+        }
+
+        #region Event Handlers
+        private void saveDataButton_Click(object sender, EventArgs e) {
+            SaveLearnsetData();
+        }
+
+        private void pokemonNameInputComboBox_SelectedIndexChanged(object sender, EventArgs e) 
+        {
+            if (Helpers.HandlersDisabled)
+            {
+                return;
+            }
+
+            Update();
+
             this._parent.TrySyncIndices((ComboBox)sender);
             Helpers.DisableHandlers();
-            UpdateAddEditStatus();
-            if (CheckDiscardChanges()) {
-                int newNumber = pokemonNameInputComboBox.SelectedIndex;
-                monNumberNumericUpDown.Value = newNumber;
-                ChangeLoadedFile(newNumber);               
+            if (CheckDiscardChanges()) 
+            {
+                ChangeLoadedFile(pokemonNameInputComboBox.SelectedIndex);
             }
             Helpers.EnableHandlers();
         }
 
         private void monNumberNumericUpDown_ValueChanged(object sender, EventArgs e) {
-            Update();
-            if (Helpers.HandlersDisabled) {
+
+            if (Helpers.HandlersDisabled)
+            {
                 return;
             }
+
+            Update();
+            
             this._parent.TrySyncIndices((NumericUpDown)sender);
             Helpers.DisableHandlers();
-            UpdateAddEditStatus();
-            if (CheckDiscardChanges()) {
-                int newNumber = (int)monNumberNumericUpDown.Value;
-                pokemonNameInputComboBox.SelectedIndex = newNumber;
-                ChangeLoadedFile(newNumber);                
+            if (CheckDiscardChanges()) 
+            {
+                ChangeLoadedFile((int)monNumberNumericUpDown.Value);
             }
             Helpers.EnableHandlers();
         }
@@ -175,10 +400,6 @@ namespace DSPRE {
             descriptorLabel.Text = "Move ID: " + moveInputComboBox.SelectedIndex;
         }
 
-        private bool CheckValidEntry() {
-            return levelNumericUpDown.Value > 0 && 
-                moveInputComboBox.SelectedIndex > 0;
-        }
         private void levelNumericUpDown_ValueChanged(object sender, EventArgs e) {
             if (currentLoadedFile == null) {
                 return;
@@ -186,61 +407,39 @@ namespace DSPRE {
             UpdateAddEditStatus();
         }
 
-        private void UpdateAddEditStatus() {
-            (byte level, ushort move) newEntry = ((byte)levelNumericUpDown.Value, (ushort)moveInputComboBox.SelectedIndex);
-
-            if (currentLoadedFile == null)
-            {
-                return;
-            }
-
-            bool duplicate = currentLoadedFile.list.Contains(newEntry);
-
-            if (duplicate) {
-                if (editMode) {
-                    editMoveButton.Enabled = false;
-                } else {
-                    addMoveButton.Enabled = false;
-                }
-                statusLabel.Text = "Entry already exists!";
-            } else {
-                bool addable = CheckValidEntry();
-                if (addable) {
-                    statusLabel.Text = "";
-                } else {
-                    statusLabel.Text = "Invalid Move ID or Level!";
-                }
-
-                if (editMode) {
-                    editMoveButton.Enabled = addable;
-                } else {
-                    addMoveButton.Enabled = addable;
-                }
-            }
-        }
-
         private void addMoveButton_Click(object sender, EventArgs e) {
-            (byte level, ushort move) newEntry = ((byte)levelNumericUpDown.Value, (ushort)moveInputComboBox.SelectedIndex);
-            currentLoadedFile.list.Add(newEntry);
-                
-            currentLoadedFile.list.Sort();
-            PopulateAllFromCurrentFile();
-            movesListBox.SelectedIndex = currentLoadedFile.list.FindIndex(x => x == newEntry);
+
+            int index = InsertEntrySafe((byte)levelNumericUpDown.Value, (ushort)moveInputComboBox.SelectedIndex);
+
+            if (index < 0) {
+                return; // Insertion failed, likely due to invalid entry
+            }
+
+            UpdateMovesListFromFile();
+            movesListBox.SelectedIndex = index;
             UpdateAddEditStatus();
-            setDirty(true);
+            SetDirty(true);
         }
 
         private void deleteMoveButton_Click(object sender, EventArgs e) {
+
+            if (currentLoadedFile == null) {
+                return;
+            }
+
             int sel = movesListBox.SelectedIndex;
             if (sel < 0) {
                 return;
             }
 
-            if (editMode) {
+            if (editMode) 
+            {
                 editMode = false;
                 movesListBox.Enabled = true;
                 UpdateButtonsOnMoveSelection();
-            } else {
+            } 
+            else 
+            {
                 currentLoadedFile.list.RemoveAt(sel);
                 movesListBox.Items.RemoveAt(sel);
 
@@ -254,7 +453,7 @@ namespace DSPRE {
 
             UpdateByEditMode();
             UpdateAddEditStatus();
-            setDirty(true);
+            SetDirty(true);
         }
 
         private void editMoveButton_Click(object sender, EventArgs e) {
@@ -268,16 +467,19 @@ namespace DSPRE {
 
                 int newSelection;
                 int oldLevel = currentLoadedFile.list[sel].level;
-                currentLoadedFile.list[sel] = newEntry;
 
-                if (newEntry.level == oldLevel) {
+                if (newEntry.level == oldLevel)
+                {
+                    currentLoadedFile.list[sel] = newEntry;
                     movesListBox.Items[sel] = ElemToString(newEntry);
                     newSelection = sel;
-                } else {
-                    currentLoadedFile.list.Sort();
-                    PopulateAllFromCurrentFile();
-                    newSelection = currentLoadedFile.list.FindIndex(x => x == newEntry);
                 }
+                else
+                {
+                    currentLoadedFile.list.RemoveAt(sel);
+                    newSelection = InsertEntrySafe(newEntry.level, newEntry.move);
+                    UpdateMovesListFromFile();
+                }             
                 
                 UpdateEntryCountLabel();
                 movesListBox.SelectedIndex = newSelection;
@@ -286,6 +488,8 @@ namespace DSPRE {
             } else {  
                 editMode = true;
                 movesListBox.Enabled = false;
+                moveUpButton.Enabled = false;
+                moveDownButton.Enabled = false;
 
                 editMoveButton.Text = editButtonNames[1];
                 deleteMoveButton.Text = deleteButtonNames[1];
@@ -296,50 +500,39 @@ namespace DSPRE {
             }
 
             UpdateByEditMode();
-            addMoveButton.Enabled = (editMode == false && CheckValidEntry());
-            setDirty(true);
-        }
-
-        private void UpdateByEditMode() {
-            UpdateButtonNames(editMode);
-        }
-
-        private void UpdateButtonNames(bool editMode) {
-            int index = editMode == false ? 0 : 1;
-            editMoveButton.Text = editButtonNames[index];
-            deleteMoveButton.Text = deleteButtonNames[index];
+            UpdateAddEditStatus();
+            SetDirty(true);
         }
 
         private void movesListBox_SelectedIndexChanged(object sender, EventArgs e) {
             UpdateButtonsOnMoveSelection();
         }
 
-        private void UpdateButtonsOnMoveSelection() {
+        private void moveUpButton_Click(object sender, EventArgs e)
+        {
             int sel = movesListBox.SelectedIndex;
-            if (sel < 0) {
-                editMoveButton.Enabled = false;
-                deleteMoveButton.Enabled = false;
+            if (!ShiftEntry(sel, -1))
+            {
                 return;
             }
-
-            editMoveButton.Enabled = true;
-            deleteMoveButton.Enabled = true;
+            UpdateMovesListFromFile();
+            movesListBox.SelectedIndex = sel-1;
+            SetDirty(true);
         }
 
-        private void UpdateEntryCountLabel(){
-            StringBuilder labelText = new StringBuilder("Entry Count: ");
-            labelText.Append(movesListBox.Items.Count);
-
-            if (movesListBox.Items.Count > LearnsetData.VanillaLimit) {
-                labelText.Append("!");
-                entryCountLabel.ForeColor = Color.FromArgb(210, 120, 0);
-                entryCountLabel.Font = new Font(entryCountLabel.Font, FontStyle.Bold);
-            } else {
-                entryCountLabel.ForeColor = Color.Black;
-                entryCountLabel.Font = new Font(entryCountLabel.Font, FontStyle.Regular);
+        private void moveDownButton_Click(object sender, EventArgs e)
+        {
+            int sel = movesListBox.SelectedIndex;
+            if (!ShiftEntry(sel, 1))
+            {
+                return;
             }
-
-            entryCountLabel.Text = labelText.ToString();
+            UpdateMovesListFromFile();
+            movesListBox.SelectedIndex = sel+1;            
+            SetDirty(true);
         }
+
+        #endregion
+
     }
 }

--- a/DS_Map/Editors/PersonalDataEditor.cs
+++ b/DS_Map/Editors/PersonalDataEditor.cs
@@ -17,7 +17,7 @@ namespace DSPRE {
         private int currentLoadedId = 0;
         private PokemonPersonalData currentLoadedFile = null;
 
-        private static bool dirty = false;
+        public bool dirty = false;
         private bool modifiedAbilities = false;
         private static readonly string formName = "Personal Data Editor";
 
@@ -87,6 +87,7 @@ namespace DSPRE {
                 dirty = false;
                 this.Text = formName;
             }
+            _parent.UpdateTabPageNames();
         }
         private void baseHpNumericUpDown_ValueChanged(object sender, EventArgs e) {
             if (Helpers.HandlersDisabled) {

--- a/DS_Map/Editors/PokemonEditor.Designer.cs
+++ b/DS_Map/Editors/PokemonEditor.Designer.cs
@@ -33,6 +33,7 @@
             this.syncChangesCheckbox = new System.Windows.Forms.CheckBox();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            this.FormClosing += PokemonEditor_FormClosing;
             this.tabControl.SuspendLayout();
             this.flowLayoutPanel1.SuspendLayout();
             this.SuspendLayout();

--- a/DS_Map/Editors/PokemonEditor.cs
+++ b/DS_Map/Editors/PokemonEditor.cs
@@ -106,5 +106,37 @@ namespace DSPRE {
             }
             Helpers.RestoreDisableHandler();
         }
+
+        public void UpdateTabPageNames()
+        {
+            if (personalEditor == null || learnsetEditor == null || evoEditor == null)
+            {
+                return;
+            }
+
+            personalPage.Text = personalEditor.Text;
+            learnsetPage.Text = learnsetEditor.Text;
+            evoPage.Text = evoEditor.Text;
+        }
+
+        private void PokemonEditor_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            if (personalEditor == null || learnsetEditor == null || evoEditor == null)
+            {
+                return;
+            }
+
+            if (personalEditor.dirty || learnsetEditor.dirty || evoEditor.dirty)
+            {
+                DialogResult result = MessageBox.Show("There are unsaved changes. Closing the editor will discard them!", "Unsaved Changes", MessageBoxButtons.OKCancel, MessageBoxIcon.Warning);
+
+                if (result != DialogResult.OK)
+                {
+                    e.Cancel = true;
+                    return;
+                }
+
+            }
+        }
     }
 }

--- a/DS_Map/UniqueList.cs
+++ b/DS_Map/UniqueList.cs
@@ -47,6 +47,22 @@ namespace DSPRE.ROMFiles {
             return false;
         }
 
+        public bool Insert(int index, T item) {
+            if (set.Contains(item)) {
+                //If the item is already in the set, we just move it to the new index
+                int oldIndex = list.FindIndex(x => x.Equals(item));
+                if (oldIndex != index) {
+                    list.Move(oldIndex, index);
+                }
+                return false; //No insertion happened
+            } else {
+                //New item, insert it
+                list.Insert(index, item);
+                set.Add(item);
+                return true; //Insertion happened
+            }
+        }
+
         // Expose some methods from the internal List
         public T Find(Predicate<T> match) {
             return list.Find(match);


### PR DESCRIPTION
This 
- does a slight refactor of the learnset editor
- adds a move up and down button for moves in the learnset
- gets rid of the sorting when adding or removing moves
- improves checking for unsaved changes